### PR TITLE
Fix Windows installation (file not found)

### DIFF
--- a/qt_installer.sh
+++ b/qt_installer.sh
@@ -43,7 +43,7 @@ install_qt_on_mac()
 
 install_qt_on_windows()
 {
-    "${DIR}/${QT_INSTALLER_DOWNLOAD_NAME}" --verbose --script "${QT_INSTALLER_SCRIPT_FILE}"
+    "./${QT_INSTALLER_DOWNLOAD_NAME}" --verbose --script "${QT_INSTALLER_SCRIPT_FILE}"
 }
 
 # Run installer


### PR DESCRIPTION
Windows users could experience "no such file or directory" errors. It was caused by discrepancy that curl saves installer to current working directory, whereas installer script searched for this file in a directory relative to installer script.

This commit ensures that the current working directory is always used.