### PR TITLE
Add a callback for question on tracking usage data

### DIFF
--- a/control_script.js
+++ b/control_script.js
@@ -92,3 +92,12 @@ Controller.prototype.FinishedPageCallback = function() {
     page().RunItCheckBox.checked = false
     proceed(buttons.FinishButton)
 }
+
+/// Question for tracking usage data, refuse it
+Controller.prototype.DynamicTelemetryPluginFormCallback = function() {
+    logCurrentPage()
+    console.log(Object.keys(page().TelemetryPluginForm.statisticGroupBox))
+    var radioButtons = page().TelemetryPluginForm.statisticGroupBox
+    radioButtons.disableStatisticRadioButton.checked = true
+    proceed()
+}


### PR DESCRIPTION
Recently, the Qt Online Installer started to collect usage statistics.  This requires adding another callback to the control script, which gives a negative response when the installer asks for allowance for tracking such data.

Without this change, the installer freezes on that dialog box.

See:
- https://github.com/skalee/non-interactive-qt-installer/pull/4
- https://www.qt.io/blog/option-to-provide-anonymous-usage-statistics-enabled